### PR TITLE
Add GitHub Action for releasing Gluon builds

### DIFF
--- a/.github/workflows/gluon_release.yml
+++ b/.github/workflows/gluon_release.yml
@@ -47,7 +47,7 @@ jobs:
         ${MX_PATH}/mx --primary-suite-path vm --dy /substratevm build
     - name: Create distribution
       run: |
-        mv vm/latest_graalvm_home graalvm-svm-linux-gluon-${RELEASE_VERSION}
+        mv sdk/latest_graalvm_home graalvm-svm-linux-gluon-${RELEASE_VERSION}
         ls -l
         ls -l graalvm-svm-linux-gluon-${RELEASE_VERSION}
         zip -r graalvm-svm-linux-gluon-${RELEASE_VERSION}.zip graalvm-svm-linux-gluon-${RELEASE_VERSION}
@@ -95,7 +95,7 @@ jobs:
         ${MX_PATH}/mx --primary-suite-path vm --dy /substratevm build
     - name: Create distribution
       run: |
-        mv vm/latest_graalvm_home graalvm-svm-darwin-gluon-${RELEASE_VERSION}
+        mv sdk/latest_graalvm_home graalvm-svm-darwin-gluon-${RELEASE_VERSION}
         zip -r graalvm-svm-darwin-gluon-${RELEASE_VERSION}.zip graalvm-svm-darwin-gluon-${RELEASE_VERSION}
     - name: Archive distribution
       uses: actions/upload-artifact@v2
@@ -127,7 +127,7 @@ jobs:
     - name: Get JDK
       run: |
         mkdir jdk-dl
-        $env:MX_PATH\mx fetch-jdk --java-distribution $env:JDK --to jdk-dl --alias $env:JAVA_HOME
+        iex "$env:MX_PATH\mx fetch-jdk --java-distribution $env:JDK --to jdk-dl --alias $env:JAVA_HOME"
     - name: Build GraalVM
       id: windows-build-graalvm
       env:
@@ -137,9 +137,9 @@ jobs:
         SKIP_LIBRARIES: polyglot
       run: |
         echo $env:JAVA_HOME
-        $env:JAVA_HOME\bin\java -version
-        $env:MX_PATH\mx --primary-suite-path vm build
-        $GRAALVM_HOME = ($env:MX_PATH\mx --primary-suite-path vm graalvm-home) | Out-String
+        iex "$env:JAVA_HOME\bin\java -version"
+        iex "$env:MX_PATH\mx --primary-suite-path vm build"
+        $GRAALVM_HOME = (iex "$env:MX_PATH\mx --primary-suite-path vm graalvm-home") | Out-String
         echo "::set-output name=graalvm-home-dir::$GRAALVM_HOME"
     - name: Create distribution
       shell: bash

--- a/.github/workflows/gluon_release.yml
+++ b/.github/workflows/gluon_release.yml
@@ -49,12 +49,13 @@ jobs:
         ${MX_PATH}/mx --dy /substratevm build
         GRAALVM_HOME=`${MX_PATH}/mx --dy /substratevm graalvm-home`
         ls -l
-        ls -l latest_graalvm_home
+        ls -R latest_graalvm_home/
         echo "::set-output name=graalvm-home-dir::${GRAALVM_HOME}"
     - name: Create distribution
       working-directory: ./vm
       run: |
-        mv ${{ steps.linux-build-graalvm.outputs.graalvm-home-dir }} graalvm-svm-linux-gluon-${RELEASE_VERSION}
+        mv latest_graalvm_home graalvm-svm-linux-gluon-${RELEASE_VERSION}
+#        mv ${{ steps.linux-build-graalvm.outputs.graalvm-home-dir }} graalvm-svm-linux-gluon-${RELEASE_VERSION}
         zip -r graalvm-svm-linux-gluon-${RELEASE_VERSION}.zip graalvm-svm-linux-gluon-${RELEASE_VERSION}
     - name: Archive distribution
       uses: actions/upload-artifact@v2
@@ -158,12 +159,10 @@ jobs:
         $GRAALVM_HOME = (iex "$env:MX_PATH\mx.cmd graalvm-home") | Out-String
         echo "::set-output name=graalvm-home-dir::$GRAALVM_HOME"
     - name: Create distribution
-      shell: bash
       working-directory: ./vm
       run: |
-        set GRAALVM_HOME=`wslpath -a ${{ steps.windows-build-graalvm.outputs.graalvm-home-dir }}`
-        mv ${GRAALVM_HOME} graalvm-svm-windows-gluon-${RELEASE_VERSION}
-        zip -r graalvm-svm-windows-gluon-${RELEASE_VERSION}.zip graalvm-svm-windows-gluon-${RELEASE_VERSION}
+        move ${{ steps.windows-build-graalvm.outputs.graalvm-home-dir }} graalvm-svm-windows-gluon-$env:RELEASE_VERSION
+        Compress-Archive -Path graalvm-svm-windows-gluon-$env:RELEASE_VERSION -DestinationPath graalvm-svm-windows-gluon-$env:RELEASE_VERSION.zip
     - name: Archive distribution
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/gluon_release.yml
+++ b/.github/workflows/gluon_release.yml
@@ -175,9 +175,6 @@ jobs:
     - uses: actions/download-artifact@v2
       with:
         path: artifacts
-    - name: List artifacts
-      run: |
-        ls -R artifacts
     - name: Create release
       uses: ncipollo/release-action@v1
       with:

--- a/.github/workflows/gluon_release.yml
+++ b/.github/workflows/gluon_release.yml
@@ -52,8 +52,9 @@ jobs:
     - name: Create distribution
       working-directory: ./vm
       run: |
-        mv ${{ steps.linux-build-graalvm.outputs.graalvm-home-dir }} graalvm-svm-linux-gluon-${RELEASE_VERSION}
-        zip -r graalvm-svm-linux-gluon-${RELEASE_VERSION}.zip graalvm-svm-linux-gluon-${RELEASE_VERSION}
+        cd ${{ steps.linux-build-graalvm.outputs.graalvm-home-dir }}/..
+        mv `ls -1 | head -n1` graalvm-svm-linux-gluon-${RELEASE_VERSION}
+        zip -r ${{ github.workspace }}/vm/graalvm-svm-linux-gluon-${RELEASE_VERSION}.zip graalvm-svm-linux-gluon-${RELEASE_VERSION}
     - name: Archive distribution
       uses: actions/upload-artifact@v2
       with:
@@ -103,9 +104,9 @@ jobs:
     - name: Create distribution
       working-directory: ./vm
       run: |
-        GRAALVM_HOME=${{ steps.darwin-build-graalvm.outputs.graalvm-home-dir }}
-        mv ${GRAALVM_HOME:0:$((${#GRAALVM_HOME}-14))} graalvm-svm-darwin-gluon-${RELEASE_VERSION}
-        zip -r graalvm-svm-darwin-gluon-${RELEASE_VERSION}.zip graalvm-svm-darwin-gluon-${RELEASE_VERSION}
+        cd ${{ steps.darwin-build-graalvm.outputs.graalvm-home-dir }}/../../..
+        mv `ls -1 | head -n1` graalvm-svm-darwin-gluon-${RELEASE_VERSION}
+        zip -r ${{ github.workspace }}/vm/graalvm-svm-darwin-gluon-${RELEASE_VERSION}.zip graalvm-svm-darwin-gluon-${RELEASE_VERSION}
     - name: Archive distribution
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/gluon_release.yml
+++ b/.github/workflows/gluon_release.yml
@@ -50,11 +50,11 @@ jobs:
         mv vm/latest_graalvm_home graalvm-svm-linux-gluon-${RELEASE_VERSION}
         cd vm && zip -r ../graalvm-svm-linux-gluon-${RELEASE_VERSION}.zip graalvm-svm-linux-gluon-${RELEASE_VERSION}
     - name: Archive distribution
-        uses: actions/upload-artifact@v2
-        with:
-          name: graalvm-zip-linux
-          path: |
-            graalvm-svm-linux-gluon-${RELEASE_VERSION}.zip
+      uses: actions/upload-artifact@v2
+      with:
+        name: graalvm-zip-linux
+        path: |
+          graalvm-svm-linux-gluon-${RELEASE_VERSION}.zip
 
 
 jobs:
@@ -96,11 +96,11 @@ jobs:
         mv vm/latest_graalvm_home graalvm-svm-darwin-gluon-${RELEASE_VERSION}
         cd vm && zip -r ../graalvm-svm-darwin-gluon-${RELEASE_VERSION}.zip graalvm-svm-darwin-gluon-${RELEASE_VERSION}
     - name: Archive distribution
-        uses: actions/upload-artifact@v2
-        with:
-          name: graalvm-zip-darwin
-          path: |
-            graalvm-svm-darwin-gluon-${RELEASE_VERSION}.zip
+      uses: actions/upload-artifact@v2
+      with:
+        name: graalvm-zip-darwin
+        path: |
+          graalvm-svm-darwin-gluon-${RELEASE_VERSION}.zip
 
 
 jobs:
@@ -147,11 +147,11 @@ jobs:
         mv vm/latest_graalvm_home graalvm-svm-windows-gluon-${RELEASE_VERSION}
         cd vm && zip -r ../graalvm-svm-windows-gluon-${RELEASE_VERSION}.zip graalvm-svm-windows-gluon-${RELEASE_VERSION}
     - name: Archive distribution
-        uses: actions/upload-artifact@v2
-        with:
-          name: graalvm-zip-windows
-          path: |
-            graalvm-svm-windows-gluon-${RELEASE_VERSION}.zip
+      uses: actions/upload-artifact@v2
+      with:
+        name: graalvm-zip-windows
+        path: |
+          graalvm-svm-windows-gluon-${RELEASE_VERSION}.zip
 
 jobs:
   create-release:

--- a/.github/workflows/gluon_release.yml
+++ b/.github/workflows/gluon_release.yml
@@ -12,7 +12,6 @@ env:
 
 jobs:
   build-graalvm-linux:
-    if: ${{ false }}  # disable temporarily
     runs-on: ubuntu-20.04
     env:
       JAVA_HOME: ${{ github.workspace }}/jdk
@@ -43,13 +42,17 @@ jobs:
         DISABLE_POLYGLOT: true
         FORCE_BASH_LAUNCHERS: false
         LINKY_LAYOUT: "*.jar"
+      working-directory: ./vm
       run: |
         echo ${JAVA_HOME}
         ${JAVA_HOME}/bin/java -version
-        ${MX_PATH}/mx --primary-suite-path vm --dy /substratevm build
-        GRAALVM_HOME=`${MX_PATH}/mx --primary-suite-path vm --dy /substratevm graalvm-home`
+        ${MX_PATH}/mx --dy /substratevm build
+        GRAALVM_HOME=`${MX_PATH}/mx --dy /substratevm graalvm-home`
+        ls -l
+        ls -l latest_graalvm_home
         echo "::set-output name=graalvm-home-dir::${GRAALVM_HOME}"
     - name: Create distribution
+      working-directory: ./vm
       run: |
         mv ${{ steps.linux-build-graalvm.outputs.graalvm-home-dir }} graalvm-svm-linux-gluon-${RELEASE_VERSION}
         zip -r graalvm-svm-linux-gluon-${RELEASE_VERSION}.zip graalvm-svm-linux-gluon-${RELEASE_VERSION}
@@ -61,7 +64,6 @@ jobs:
           graalvm-svm-linux-gluon-${{ env.RELEASE_VERSION }}.zip
 
   build-graalvm-darwin:
-    if: ${{ false }}  # disable temporarily
     runs-on: macos-10.15
     env:
       JAVA_ROOT: ${{ github.workspace }}/jdk
@@ -93,13 +95,15 @@ jobs:
         DISABLE_POLYGLOT: true
         FORCE_BASH_LAUNCHERS: false
         LINKY_LAYOUT: "*.jar"
+      working-directory: ./vm
       run: |
         echo ${JAVA_HOME}
         ${JAVA_HOME}/bin/java -version
-        ${MX_PATH}/mx --primary-suite-path vm --dy /substratevm build
-        GRAALVM_HOME=`${MX_PATH}/mx --primary-suite-path vm --dy /substratevm graalvm-home`
+        ${MX_PATH}/mx --dy /substratevm build
+        GRAALVM_HOME=`${MX_PATH}/mx --dy /substratevm graalvm-home`
         echo "::set-output name=graalvm-home-dir::${GRAALVM_HOME}"
     - name: Create distribution
+      working-directory: ./vm
       run: |
         mv ${{ steps.darwin-build-graalvm.outputs.graalvm-home-dir }} graalvm-svm-darwin-gluon-${RELEASE_VERSION}
         zip -r graalvm-svm-darwin-gluon-${RELEASE_VERSION}.zip graalvm-svm-darwin-gluon-${RELEASE_VERSION}
@@ -145,17 +149,19 @@ jobs:
         EXCLUDE_COMPONENTS: nju,llp,dis,pbm,llmulrl
         FORCE_BASH_LAUNCHERS: polyglot
         SKIP_LIBRARIES: polyglot
+      working-directory: ./vm
       run: |
         echo $env:JAVA_HOME
         echo $env:PATH
         iex "$env:JAVA_HOME\bin\java -version"
-        iex "$env:MX_PATH\mx.cmd --primary-suite-path vm build"
-        $GRAALVM_HOME = (iex "$env:MX_PATH\mx.cmd --primary-suite-path vm graalvm-home") | Out-String
+        iex "$env:MX_PATH\mx.cmd build"
+        $GRAALVM_HOME = (iex "$env:MX_PATH\mx.cmd graalvm-home") | Out-String
         echo "::set-output name=graalvm-home-dir::$GRAALVM_HOME"
     - name: Create distribution
       shell: bash
+      working-directory: ./vm
       run: |
-        set GRAALVM_HOME=`wslpath -a ${{ steps.windows-build-graalvm.outputs.graalvm-home-dir }}
+        set GRAALVM_HOME=`wslpath -a ${{ steps.windows-build-graalvm.outputs.graalvm-home-dir }}`
         mv ${GRAALVM_HOME} graalvm-svm-windows-gluon-${RELEASE_VERSION}
         zip -r graalvm-svm-windows-gluon-${RELEASE_VERSION}.zip graalvm-svm-windows-gluon-${RELEASE_VERSION}
     - name: Archive distribution

--- a/.github/workflows/gluon_release.yml
+++ b/.github/workflows/gluon_release.yml
@@ -36,6 +36,7 @@ jobs:
         mkdir jdk-dl
         ${MX_PATH}/mx fetch-jdk --java-distribution ${JDK} --to jdk-dl --alias ${JAVA_HOME}
     - name: Build GraalVM
+      id: linux-build-graalvm
       env:
         DISABLE_LIBPOLYGLOT: true
         DISABLE_POLYGLOT: true
@@ -45,11 +46,11 @@ jobs:
         echo ${JAVA_HOME}
         ${JAVA_HOME}/bin/java -version
         ${MX_PATH}/mx --primary-suite-path vm --dy /substratevm build
+        GRAALVM_HOME=`${MX_PATH}/mx --primary-suite-path vm --dy /substratevm graalvm-home`
+        echo "::set-output name=graalvm-home-dir::${GRAALVM_HOME}"
     - name: Create distribution
       run: |
-        mv sdk/latest_graalvm_home graalvm-svm-linux-gluon-${RELEASE_VERSION}
-        ls -l
-        ls -l graalvm-svm-linux-gluon-${RELEASE_VERSION}
+        mv ${{ steps.linux-build-graalvm.outputs.graalvm-home-dir }} graalvm-svm-linux-gluon-${RELEASE_VERSION}
         zip -r graalvm-svm-linux-gluon-${RELEASE_VERSION}.zip graalvm-svm-linux-gluon-${RELEASE_VERSION}
     - name: Archive distribution
       uses: actions/upload-artifact@v2
@@ -84,6 +85,7 @@ jobs:
         mkdir jdk-dl
         ${MX_PATH}/mx fetch-jdk --java-distribution ${JDK} --to jdk-dl --alias ${JAVA_ROOT}
     - name: Build GraalVM
+      id: darwin-build-graalvm
       env:
         DISABLE_LIBPOLYGLOT: true
         DISABLE_POLYGLOT: true
@@ -93,9 +95,11 @@ jobs:
         echo ${JAVA_HOME}
         ${JAVA_HOME}/bin/java -version
         ${MX_PATH}/mx --primary-suite-path vm --dy /substratevm build
+        GRAALVM_HOME=`${MX_PATH}/mx --primary-suite-path vm --dy /substratevm graalvm-home`
+        echo "::set-output name=graalvm-home-dir::${GRAALVM_HOME}"
     - name: Create distribution
       run: |
-        mv sdk/latest_graalvm_home graalvm-svm-darwin-gluon-${RELEASE_VERSION}
+        mv ${{ steps.darwin-build-graalvm.outputs.graalvm-home-dir }} graalvm-svm-darwin-gluon-${RELEASE_VERSION}
         zip -r graalvm-svm-darwin-gluon-${RELEASE_VERSION}.zip graalvm-svm-darwin-gluon-${RELEASE_VERSION}
     - name: Archive distribution
       uses: actions/upload-artifact@v2

--- a/.github/workflows/gluon_release.yml
+++ b/.github/workflows/gluon_release.yml
@@ -40,7 +40,7 @@ jobs:
         DISABLE_LIBPOLYGLOT: true
         DISABLE_POLYGLOT: true
         FORCE_BASH_LAUNCHERS: false
-        LINKY_LAYOUT: *.jar
+        LINKY_LAYOUT: "*.jar"
       run: |
         echo ${JAVA_HOME}
         ${JAVA_HOME}/bin/java -version
@@ -86,7 +86,7 @@ jobs:
         DISABLE_LIBPOLYGLOT: true
         DISABLE_POLYGLOT: true
         FORCE_BASH_LAUNCHERS: false
-        LINKY_LAYOUT: *.jar
+        LINKY_LAYOUT: "*.jar"
       run: |
         echo ${JAVA_HOME}
         ${JAVA_HOME}/bin/java -version

--- a/.github/workflows/gluon_release.yml
+++ b/.github/workflows/gluon_release.yml
@@ -12,6 +12,7 @@ env:
 
 jobs:
   build-graalvm-linux:
+    if: ${{ false }}  # disable temporarily
     runs-on: ubuntu-20.04
     env:
       JAVA_HOME: ${{ github.workspace }}/jdk
@@ -60,6 +61,7 @@ jobs:
           graalvm-svm-linux-gluon-${{ env.RELEASE_VERSION }}.zip
 
   build-graalvm-darwin:
+    if: ${{ false }}  # disable temporarily
     runs-on: macos-10.15
     env:
       JAVA_ROOT: ${{ github.workspace }}/jdk
@@ -141,6 +143,9 @@ jobs:
         SKIP_LIBRARIES: polyglot
       run: |
         echo $env:JAVA_HOME
+        echo $env:PATH
+        gcm dumpbin
+        gcm dumpbin.exe
         iex "$env:JAVA_HOME\bin\java -version"
         iex "$env:MX_PATH\mx.cmd --primary-suite-path vm build"
         $GRAALVM_HOME = (iex "$env:MX_PATH\mx.cmd --primary-suite-path vm graalvm-home") | Out-String
@@ -148,7 +153,8 @@ jobs:
     - name: Create distribution
       shell: bash
       run: |
-        mv ${{ steps.windows-build-graalvm.outputs.graalvm-home-dir }} graalvm-svm-windows-gluon-${RELEASE_VERSION}
+        set GRAALVM_HOME=`wslpath -a ${{ steps.windows-build-graalvm.outputs.graalvm-home-dir }}
+        mv ${GRAALVM_HOME} graalvm-svm-windows-gluon-${RELEASE_VERSION}
         zip -r graalvm-svm-windows-gluon-${RELEASE_VERSION}.zip graalvm-svm-windows-gluon-${RELEASE_VERSION}
     - name: Archive distribution
       uses: actions/upload-artifact@v2

--- a/.github/workflows/gluon_release.yml
+++ b/.github/workflows/gluon_release.yml
@@ -8,12 +8,14 @@ on:
 env:
   RELEASE_VERSION: 21.1.0
   LANG: en_US.UTF-8
-  JAVA_HOME: ${{ github.workspace }}/jdk
-  MX_PATH: ${{ github.workspace }}/mx
+  JDK: "labsjdk-ce-11"
 
 jobs:
   build-graalvm-linux:
     runs-on: ubuntu-20.04
+    env:
+      JAVA_HOME: ${{ github.workspace }}/jdk
+      MX_PATH: ${{ github.workspace }}/mx
     steps:
     - uses: actions/checkout@v2
       with:
@@ -30,8 +32,6 @@ jobs:
         key: ${{ runner.os }}-mx-${{ hashFiles('**/suite.py') }}
         restore-keys: ${{ runner.os }}-mx-
     - name: Get JDK
-      env:
-        JDK: "labsjdk-ce-11"
       run: |
         mkdir jdk-dl
         ${MX_PATH}/mx fetch-jdk --java-distribution ${JDK} --to jdk-dl --alias ${JAVA_HOME}
@@ -58,6 +58,10 @@ jobs:
 
   build-graalvm-darwin:
     runs-on: macos-10.15
+    env:
+      JAVA_ROOT: ${{ github.workspace }}/jdk
+      JAVA_HOME: ${{ github.workspace }}/jdk/Contents/Home
+      MX_PATH: ${{ github.workspace }}/mx
     steps:
     - uses: actions/checkout@v2
       with:
@@ -74,11 +78,9 @@ jobs:
         key: ${{ runner.os }}-mx-${{ hashFiles('**/suite.py') }}
         restore-keys: ${{ runner.os }}-mx-
     - name: Get JDK
-      env:
-        JDK: "labsjdk-ce-11"
       run: |
         mkdir jdk-dl
-        ${MX_PATH}/mx fetch-jdk --java-distribution ${JDK} --to jdk-dl --alias ${JAVA_HOME}
+        ${MX_PATH}/mx fetch-jdk --java-distribution ${JDK} --to jdk-dl --alias ${JAVA_ROOT}
     - name: Build GraalVM
       env:
         DISABLE_LIBPOLYGLOT: true
@@ -102,6 +104,9 @@ jobs:
 
   build-graalvm-windows:
     runs-on: windows-2019
+    env:
+      JAVA_HOME: ${{ github.workspace }}\jdk
+      MX_PATH: ${{ github.workspace }}\mx
     steps:
     - uses: actions/checkout@v2
       with:
@@ -118,11 +123,9 @@ jobs:
         key: ${{ runner.os }}-mx-${{ hashFiles('**/suite.py') }}
         restore-keys: ${{ runner.os }}-mx-
     - name: Get JDK
-      env:
-        JDK: "labsjdk-ce-11"
       run: |
         mkdir jdk-dl
-        ${MX_PATH}\mx fetch-jdk --java-distribution ${JDK} --to jdk-dl --alias ${JAVA_HOME}
+        $MX_PATH\mx fetch-jdk --java-distribution $JDK --to jdk-dl --alias $JAVA_HOME
     - name: Build GraalVM
       id: windows-build-graalvm
       env:
@@ -131,10 +134,10 @@ jobs:
         FORCE_BASH_LAUNCHERS: polyglot
         SKIP_LIBRARIES: polyglot
       run: |
-        echo ${JAVA_HOME}
-        ${JAVA_HOME}\bin\java -version
-        ${MX_PATH}\mx --primary-suite-path vm build
-        $GRAALVM_HOME = (${MX_PATH}\mx --primary-suite-path vm graalvm-home) | Out-String
+        echo $JAVA_HOME
+        $JAVA_HOME\bin\java -version
+        $MX_PATH\mx --primary-suite-path vm build
+        $GRAALVM_HOME = ($MX_PATH\mx --primary-suite-path vm graalvm-home) | Out-String
         echo "::set-output name=graalvm-home-dir::$GRAALVM_HOME"
     - name: Create distribution
       shell: bash

--- a/.github/workflows/gluon_release.yml
+++ b/.github/workflows/gluon_release.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Create distribution
       working-directory: ./vm
       run: |
-        mv latest_graalvm_home graalvm-svm-linux-gluon-${RELEASE_VERSION}
+        mv latest_graalvm_home graalvm-svm-darwin-gluon-${RELEASE_VERSION}
         zip -r graalvm-svm-darwin-gluon-${RELEASE_VERSION}.zip graalvm-svm-darwin-gluon-${RELEASE_VERSION}
     - name: Archive distribution
       uses: actions/upload-artifact@v2
@@ -148,7 +148,7 @@ jobs:
         echo $env:JAVA_HOME
         iex "$env:JAVA_HOME\bin\java -version"
         iex "$env:MX_PATH\mx.cmd build"
-        $GRAALVM_HOME = (iex "$env:MX_PATH\mx.cmd graalvm-home") | Out-String
+        $GRAALVM_HOME = ((iex "$env:MX_PATH\mx.cmd graalvm-home") | Out-String).trim()
         Get-ChildItem -Path $GRAALVM_HOME
         echo "::set-output name=graalvm-home-dir::$GRAALVM_HOME"
     - name: Create distribution

--- a/.github/workflows/gluon_release.yml
+++ b/.github/workflows/gluon_release.yml
@@ -47,10 +47,6 @@ jobs:
         echo ${JAVA_HOME}
         ${JAVA_HOME}/bin/java -version
         ${MX_PATH}/mx --dy /substratevm build
-        GRAALVM_HOME=`${MX_PATH}/mx --dy /substratevm graalvm-home`
-        ls -l
-        ls -R latest_graalvm_home/
-        echo "::set-output name=graalvm-home-dir::${GRAALVM_HOME}"
     - name: Create distribution
       working-directory: ./vm
       run: |
@@ -61,7 +57,7 @@ jobs:
       with:
         name: graalvm-zip-linux
         path: |
-          graalvm-svm-linux-gluon-${{ env.RELEASE_VERSION }}.zip
+          vm/graalvm-svm-linux-gluon-${{ env.RELEASE_VERSION }}.zip
 
   build-graalvm-darwin:
     runs-on: macos-10.15
@@ -100,19 +96,17 @@ jobs:
         echo ${JAVA_HOME}
         ${JAVA_HOME}/bin/java -version
         ${MX_PATH}/mx --dy /substratevm build
-        GRAALVM_HOME=`${MX_PATH}/mx --dy /substratevm graalvm-home`
-        echo "::set-output name=graalvm-home-dir::${GRAALVM_HOME}"
     - name: Create distribution
       working-directory: ./vm
       run: |
-        mv ${{ steps.darwin-build-graalvm.outputs.graalvm-home-dir }} graalvm-svm-darwin-gluon-${RELEASE_VERSION}
+        mv latest_graalvm_home graalvm-svm-linux-gluon-${RELEASE_VERSION}
         zip -r graalvm-svm-darwin-gluon-${RELEASE_VERSION}.zip graalvm-svm-darwin-gluon-${RELEASE_VERSION}
     - name: Archive distribution
       uses: actions/upload-artifact@v2
       with:
         name: graalvm-zip-darwin
         path: |
-          graalvm-svm-darwin-gluon-${{ env.RELEASE_VERSION }}.zip
+          vm/graalvm-svm-darwin-gluon-${{ env.RELEASE_VERSION }}.zip
 
   build-graalvm-windows:
     runs-on: windows-2019
@@ -152,10 +146,10 @@ jobs:
       working-directory: ./vm
       run: |
         echo $env:JAVA_HOME
-        echo $env:PATH
         iex "$env:JAVA_HOME\bin\java -version"
         iex "$env:MX_PATH\mx.cmd build"
         $GRAALVM_HOME = (iex "$env:MX_PATH\mx.cmd graalvm-home") | Out-String
+        Get-ChildItem -Path $GRAALVM_HOME
         echo "::set-output name=graalvm-home-dir::$GRAALVM_HOME"
     - name: Create distribution
       working-directory: ./vm
@@ -167,7 +161,7 @@ jobs:
       with:
         name: graalvm-zip-windows
         path: |
-          graalvm-svm-windows-gluon-${{ env.RELEASE_VERSION }}.zip
+          vm/graalvm-svm-windows-gluon-${{ env.RELEASE_VERSION }}.zip
 
   create-release:
     runs-on: ubuntu-20.04

--- a/.github/workflows/gluon_release.yml
+++ b/.github/workflows/gluon_release.yml
@@ -125,20 +125,15 @@ jobs:
         ${MX_PATH}/mx fetch-jdk --java-distribution ${JDK} --to jdk-dl --alias ${JAVA_HOME}
     - name: Build GraalVM
       env:
-        DEFAULT_DYNAMIC_IMPORTS=/substratevm,/tools
-        EXCLUDE_COMPONENTS=nju,llp,dis,pbm,llmulrl
-        FORCE_BASH_LAUNCHERS=polyglot
-        SKIP_LIBRARIES=polyglot
+        DEFAULT_DYNAMIC_IMPORTS: /substratevm,/tools
+        EXCLUDE_COMPONENTS: nju,llp,dis,pbm,llmulrl
+        FORCE_BASH_LAUNCHERS: polyglot
+        SKIP_LIBRARIES: polyglot
       run: |
         echo ${JAVA_HOME}
         ${JAVA_HOME}/bin/java -version
         ${MX_PATH}/mx --primary-suite-path vm build
     - name: Create distribution
-      env:
-        DEFAULT_DYNAMIC_IMPORTS=/substratevm,/tools
-        EXCLUDE_COMPONENTS=nju,llp,dis,pbm,llmulrl
-        FORCE_BASH_LAUNCHERS=polyglot
-        SKIP_LIBRARIES=polyglot
       run: |
         mv vm/latest_graalvm_home graalvm-svm-windows-gluon-${RELEASE_VERSION}
         cd vm && zip -r ../graalvm-svm-windows-gluon-${RELEASE_VERSION}.zip graalvm-svm-windows-gluon-${RELEASE_VERSION}

--- a/.github/workflows/gluon_release.yml
+++ b/.github/workflows/gluon_release.yml
@@ -55,7 +55,6 @@ jobs:
       working-directory: ./vm
       run: |
         mv latest_graalvm_home graalvm-svm-linux-gluon-${RELEASE_VERSION}
-#        mv ${{ steps.linux-build-graalvm.outputs.graalvm-home-dir }} graalvm-svm-linux-gluon-${RELEASE_VERSION}
         zip -r graalvm-svm-linux-gluon-${RELEASE_VERSION}.zip graalvm-svm-linux-gluon-${RELEASE_VERSION}
     - name: Archive distribution
       uses: actions/upload-artifact@v2

--- a/.github/workflows/gluon_release.yml
+++ b/.github/workflows/gluon_release.yml
@@ -47,7 +47,8 @@ jobs:
         ${MX_PATH}/mx --primary-suite-path vm --dy /substratevm build
     - name: Create distribution
       run: |
-        mv vm/latest_graalvm_home graalvm-svm-linux-gluon-${RELEASE_VERSION}
+        ls -R
+        mv latest_graalvm_home graalvm-svm-linux-gluon-${RELEASE_VERSION}
         zip -r graalvm-svm-linux-gluon-${RELEASE_VERSION}.zip graalvm-svm-linux-gluon-${RELEASE_VERSION}
     - name: Archive distribution
       uses: actions/upload-artifact@v2
@@ -93,7 +94,7 @@ jobs:
         ${MX_PATH}/mx --primary-suite-path vm --dy /substratevm build
     - name: Create distribution
       run: |
-        mv vm/latest_graalvm_home graalvm-svm-darwin-gluon-${RELEASE_VERSION}
+        mv latest_graalvm_home graalvm-svm-darwin-gluon-${RELEASE_VERSION}
         zip -r graalvm-svm-darwin-gluon-${RELEASE_VERSION}.zip graalvm-svm-darwin-gluon-${RELEASE_VERSION}
     - name: Archive distribution
       uses: actions/upload-artifact@v2

--- a/.github/workflows/gluon_release.yml
+++ b/.github/workflows/gluon_release.yml
@@ -127,7 +127,7 @@ jobs:
     - name: Get JDK
       run: |
         mkdir jdk-dl
-        iex "$env:MX_PATH\mx fetch-jdk --java-distribution $env:JDK --to jdk-dl --alias $env:JAVA_HOME"
+        iex "$env:MX_PATH\mx.cmd fetch-jdk --java-distribution $env:JDK --to jdk-dl --alias $env:JAVA_HOME"
     - name: Build GraalVM
       id: windows-build-graalvm
       env:
@@ -138,8 +138,8 @@ jobs:
       run: |
         echo $env:JAVA_HOME
         iex "$env:JAVA_HOME\bin\java -version"
-        iex "$env:MX_PATH\mx --primary-suite-path vm build"
-        $GRAALVM_HOME = (iex "$env:MX_PATH\mx --primary-suite-path vm graalvm-home") | Out-String
+        iex "$env:MX_PATH\mx.cmd --primary-suite-path vm build"
+        $GRAALVM_HOME = (iex "$env:MX_PATH\mx.cmd --primary-suite-path vm graalvm-home") | Out-String
         echo "::set-output name=graalvm-home-dir::$GRAALVM_HOME"
     - name: Create distribution
       shell: bash

--- a/.github/workflows/gluon_release.yml
+++ b/.github/workflows/gluon_release.yml
@@ -47,10 +47,12 @@ jobs:
         echo ${JAVA_HOME}
         ${JAVA_HOME}/bin/java -version
         ${MX_PATH}/mx --dy /substratevm build
+        GRAALVM_HOME=`${MX_PATH}/mx --dy /substratevm graalvm-home`
+        echo "::set-output name=graalvm-home-dir::$GRAALVM_HOME"
     - name: Create distribution
       working-directory: ./vm
       run: |
-        mv latest_graalvm_home graalvm-svm-linux-gluon-${RELEASE_VERSION}
+        mv ${{ steps.linux-build-graalvm.outputs.graalvm-home-dir }} graalvm-svm-linux-gluon-${RELEASE_VERSION}
         zip -r graalvm-svm-linux-gluon-${RELEASE_VERSION}.zip graalvm-svm-linux-gluon-${RELEASE_VERSION}
     - name: Archive distribution
       uses: actions/upload-artifact@v2
@@ -96,10 +98,13 @@ jobs:
         echo ${JAVA_HOME}
         ${JAVA_HOME}/bin/java -version
         ${MX_PATH}/mx --dy /substratevm build
+        GRAALVM_HOME=`${MX_PATH}/mx --dy /substratevm graalvm-home`
+        echo "::set-output name=graalvm-home-dir::$GRAALVM_HOME"
     - name: Create distribution
       working-directory: ./vm
       run: |
-        mv latest_graalvm_home graalvm-svm-darwin-gluon-${RELEASE_VERSION}
+        GRAALVM_HOME=${{ steps.darwin-build-graalvm.outputs.graalvm-home-dir }}
+        mv ${GRAALVM_HOME:0:$((${#GRAALVM_HOME}-14))} graalvm-svm-darwin-gluon-${RELEASE_VERSION}
         zip -r graalvm-svm-darwin-gluon-${RELEASE_VERSION}.zip graalvm-svm-darwin-gluon-${RELEASE_VERSION}
     - name: Archive distribution
       uses: actions/upload-artifact@v2

--- a/.github/workflows/gluon_release.yml
+++ b/.github/workflows/gluon_release.yml
@@ -47,15 +47,16 @@ jobs:
         ${MX_PATH}/mx --primary-suite-path vm --dy /substratevm build
     - name: Create distribution
       run: |
-        ls -R
-        mv latest_graalvm_home graalvm-svm-linux-gluon-${RELEASE_VERSION}
+        mv vm/latest_graalvm_home graalvm-svm-linux-gluon-${RELEASE_VERSION}
+        ls -l
+        ls -l graalvm-svm-linux-gluon-${RELEASE_VERSION}
         zip -r graalvm-svm-linux-gluon-${RELEASE_VERSION}.zip graalvm-svm-linux-gluon-${RELEASE_VERSION}
     - name: Archive distribution
       uses: actions/upload-artifact@v2
       with:
         name: graalvm-zip-linux
         path: |
-          graalvm-svm-linux-gluon-${RELEASE_VERSION}.zip
+          graalvm-svm-linux-gluon-${{ env.RELEASE_VERSION }}.zip
 
   build-graalvm-darwin:
     runs-on: macos-10.15
@@ -94,14 +95,14 @@ jobs:
         ${MX_PATH}/mx --primary-suite-path vm --dy /substratevm build
     - name: Create distribution
       run: |
-        mv latest_graalvm_home graalvm-svm-darwin-gluon-${RELEASE_VERSION}
+        mv vm/latest_graalvm_home graalvm-svm-darwin-gluon-${RELEASE_VERSION}
         zip -r graalvm-svm-darwin-gluon-${RELEASE_VERSION}.zip graalvm-svm-darwin-gluon-${RELEASE_VERSION}
     - name: Archive distribution
       uses: actions/upload-artifact@v2
       with:
         name: graalvm-zip-darwin
         path: |
-          graalvm-svm-darwin-gluon-${RELEASE_VERSION}.zip
+          graalvm-svm-darwin-gluon-${{ env.RELEASE_VERSION }}.zip
 
   build-graalvm-windows:
     runs-on: windows-2019
@@ -126,7 +127,7 @@ jobs:
     - name: Get JDK
       run: |
         mkdir jdk-dl
-        $MX_PATH\mx fetch-jdk --java-distribution $JDK --to jdk-dl --alias $JAVA_HOME
+        $env:MX_PATH\mx fetch-jdk --java-distribution $env:JDK --to jdk-dl --alias $env:JAVA_HOME
     - name: Build GraalVM
       id: windows-build-graalvm
       env:
@@ -135,10 +136,10 @@ jobs:
         FORCE_BASH_LAUNCHERS: polyglot
         SKIP_LIBRARIES: polyglot
       run: |
-        echo $JAVA_HOME
-        $JAVA_HOME\bin\java -version
-        $MX_PATH\mx --primary-suite-path vm build
-        $GRAALVM_HOME = ($MX_PATH\mx --primary-suite-path vm graalvm-home) | Out-String
+        echo $env:JAVA_HOME
+        $env:JAVA_HOME\bin\java -version
+        $env:MX_PATH\mx --primary-suite-path vm build
+        $GRAALVM_HOME = ($env:MX_PATH\mx --primary-suite-path vm graalvm-home) | Out-String
         echo "::set-output name=graalvm-home-dir::$GRAALVM_HOME"
     - name: Create distribution
       shell: bash
@@ -150,7 +151,7 @@ jobs:
       with:
         name: graalvm-zip-windows
         path: |
-          graalvm-svm-windows-gluon-${RELEASE_VERSION}.zip
+          graalvm-svm-windows-gluon-${{ env.RELEASE_VERSION }}.zip
 
   create-release:
     runs-on: ubuntu-20.04

--- a/.github/workflows/gluon_release.yml
+++ b/.github/workflows/gluon_release.yml
@@ -56,8 +56,6 @@ jobs:
         path: |
           graalvm-svm-linux-gluon-${RELEASE_VERSION}.zip
 
-
-jobs:
   build-graalvm-darwin:
     runs-on: macos-11.0
     steps:
@@ -102,8 +100,6 @@ jobs:
         path: |
           graalvm-svm-darwin-gluon-${RELEASE_VERSION}.zip
 
-
-jobs:
   build-graalvm-windows:
     runs-on: windows-2019
     steps:
@@ -153,7 +149,6 @@ jobs:
         path: |
           graalvm-svm-windows-gluon-${RELEASE_VERSION}.zip
 
-jobs:
   create-release:
     runs-on: ubuntu-20.04
     needs:

--- a/.github/workflows/gluon_release.yml
+++ b/.github/workflows/gluon_release.yml
@@ -134,6 +134,10 @@ jobs:
       run: |
         mkdir jdk-dl
         iex "$env:MX_PATH\mx.cmd fetch-jdk --java-distribution $env:JDK --to jdk-dl --alias $env:JAVA_HOME"
+    - name: Set up Visual Studio shell
+      uses: egor-tensin/vs-shell@v2
+      with:
+        arch: x64
     - name: Build GraalVM
       id: windows-build-graalvm
       env:
@@ -144,8 +148,6 @@ jobs:
       run: |
         echo $env:JAVA_HOME
         echo $env:PATH
-        gcm dumpbin
-        gcm dumpbin.exe
         iex "$env:JAVA_HOME\bin\java -version"
         iex "$env:MX_PATH\mx.cmd --primary-suite-path vm build"
         $GRAALVM_HOME = (iex "$env:MX_PATH\mx.cmd --primary-suite-path vm graalvm-home") | Out-String

--- a/.github/workflows/gluon_release.yml
+++ b/.github/workflows/gluon_release.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Create distribution
       run: |
         mv vm/latest_graalvm_home graalvm-svm-linux-gluon-${RELEASE_VERSION}
-        cd vm && zip -r ../graalvm-svm-linux-gluon-${RELEASE_VERSION}.zip graalvm-svm-linux-gluon-${RELEASE_VERSION}
+        zip -r graalvm-svm-linux-gluon-${RELEASE_VERSION}.zip graalvm-svm-linux-gluon-${RELEASE_VERSION}
     - name: Archive distribution
       uses: actions/upload-artifact@v2
       with:
@@ -57,7 +57,7 @@ jobs:
           graalvm-svm-linux-gluon-${RELEASE_VERSION}.zip
 
   build-graalvm-darwin:
-    runs-on: macos-11.0
+    runs-on: macos-10.15
     steps:
     - uses: actions/checkout@v2
       with:
@@ -92,7 +92,7 @@ jobs:
     - name: Create distribution
       run: |
         mv vm/latest_graalvm_home graalvm-svm-darwin-gluon-${RELEASE_VERSION}
-        cd vm && zip -r ../graalvm-svm-darwin-gluon-${RELEASE_VERSION}.zip graalvm-svm-darwin-gluon-${RELEASE_VERSION}
+        zip -r graalvm-svm-darwin-gluon-${RELEASE_VERSION}.zip graalvm-svm-darwin-gluon-${RELEASE_VERSION}
     - name: Archive distribution
       uses: actions/upload-artifact@v2
       with:
@@ -122,8 +122,9 @@ jobs:
         JDK: "labsjdk-ce-11"
       run: |
         mkdir jdk-dl
-        ${MX_PATH}/mx fetch-jdk --java-distribution ${JDK} --to jdk-dl --alias ${JAVA_HOME}
+        ${MX_PATH}\mx fetch-jdk --java-distribution ${JDK} --to jdk-dl --alias ${JAVA_HOME}
     - name: Build GraalVM
+      id: windows-build-graalvm
       env:
         DEFAULT_DYNAMIC_IMPORTS: /substratevm,/tools
         EXCLUDE_COMPONENTS: nju,llp,dis,pbm,llmulrl
@@ -131,12 +132,15 @@ jobs:
         SKIP_LIBRARIES: polyglot
       run: |
         echo ${JAVA_HOME}
-        ${JAVA_HOME}/bin/java -version
-        ${MX_PATH}/mx --primary-suite-path vm build
+        ${JAVA_HOME}\bin\java -version
+        ${MX_PATH}\mx --primary-suite-path vm build
+        $GRAALVM_HOME = (${MX_PATH}\mx --primary-suite-path vm graalvm-home) | Out-String
+        echo "::set-output name=graalvm-home-dir::$GRAALVM_HOME"
     - name: Create distribution
+      shell: bash
       run: |
-        mv vm/latest_graalvm_home graalvm-svm-windows-gluon-${RELEASE_VERSION}
-        cd vm && zip -r ../graalvm-svm-windows-gluon-${RELEASE_VERSION}.zip graalvm-svm-windows-gluon-${RELEASE_VERSION}
+        mv ${{ steps.windows-build-graalvm.outputs.graalvm-home-dir }} graalvm-svm-windows-gluon-${RELEASE_VERSION}
+        zip -r graalvm-svm-windows-gluon-${RELEASE_VERSION}.zip graalvm-svm-windows-gluon-${RELEASE_VERSION}
     - name: Archive distribution
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/gluon_release.yml
+++ b/.github/workflows/gluon_release.yml
@@ -6,7 +6,7 @@ on:
       - '*'
 
 env:
-  RELEASE_VERSION: 21.1.0
+  RELEASE_VERSION: 21.1.0-dev
   LANG: en_US.UTF-8
   JDK: "labsjdk-ce-11"
 
@@ -149,7 +149,6 @@ jobs:
         iex "$env:JAVA_HOME\bin\java -version"
         iex "$env:MX_PATH\mx.cmd build"
         $GRAALVM_HOME = ((iex "$env:MX_PATH\mx.cmd graalvm-home") | Out-String).trim()
-        Get-ChildItem -Path $GRAALVM_HOME
         echo "::set-output name=graalvm-home-dir::$GRAALVM_HOME"
     - name: Create distribution
       working-directory: ./vm
@@ -176,6 +175,9 @@ jobs:
     - uses: actions/download-artifact@v2
       with:
         path: artifacts
+    - name: List artifacts
+      run: |
+        ls -R artifacts
     - name: Create release
       uses: ncipollo/release-action@v1
       with:
@@ -184,4 +186,4 @@ jobs:
           This is a Gluon build of GraalVM.
           Based on Gluon Graal commit: ${{ github.sha }}
         token: ${{ secrets.GITHUB_TOKEN }}
-        artifacts: artifacts/*.zip
+        artifacts: "artifacts/graalvm-zip-linux/*.zip,artifacts/graalvm-zip-darwin/*.zip,artifacts/graalvm-zip-windows/*.zip"

--- a/.github/workflows/gluon_release.yml
+++ b/.github/workflows/gluon_release.yml
@@ -1,0 +1,178 @@
+name: Gluon Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+env:
+  RELEASE_VERSION: 21.1.0
+  LANG: en_US.UTF-8
+  JAVA_HOME: ${{ github.workspace }}/jdk
+  MX_PATH: ${{ github.workspace }}/mx
+
+jobs:
+  build-graalvm-linux:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+    - uses: actions/checkout@v2
+      with:
+        repository: graalvm/mx.git
+        fetch-depth: 1
+        ref: master
+        path: ${{ env.MX_PATH }}
+    - uses: actions/cache@v1
+      with:
+        path: ~/.mx
+        key: ${{ runner.os }}-mx-${{ hashFiles('**/suite.py') }}
+        restore-keys: ${{ runner.os }}-mx-
+    - name: Get JDK
+      env:
+        JDK: "labsjdk-ce-11"
+      run: |
+        mkdir jdk-dl
+        ${MX_PATH}/mx fetch-jdk --java-distribution ${JDK} --to jdk-dl --alias ${JAVA_HOME}
+    - name: Build GraalVM
+      env:
+        DISABLE_LIBPOLYGLOT: true
+        DISABLE_POLYGLOT: true
+        FORCE_BASH_LAUNCHERS: false
+        LINKY_LAYOUT: *.jar
+      run: |
+        echo ${JAVA_HOME}
+        ${JAVA_HOME}/bin/java -version
+        ${MX_PATH}/mx --primary-suite-path vm --dy /substratevm build
+    - name: Create distribution
+      run: |
+        mv vm/latest_graalvm_home graalvm-svm-linux-gluon-${RELEASE_VERSION}
+        cd vm && zip -r ../graalvm-svm-linux-gluon-${RELEASE_VERSION}.zip graalvm-svm-linux-gluon-${RELEASE_VERSION}
+    - name: Archive distribution
+        uses: actions/upload-artifact@v2
+        with:
+          name: graalvm-zip-linux
+          path: |
+            graalvm-svm-linux-gluon-${RELEASE_VERSION}.zip
+
+
+jobs:
+  build-graalvm-darwin:
+    runs-on: macos-11.0
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+    - uses: actions/checkout@v2
+      with:
+        repository: graalvm/mx.git
+        fetch-depth: 1
+        ref: master
+        path: ${{ env.MX_PATH }}
+    - uses: actions/cache@v1
+      with:
+        path: ~/.mx
+        key: ${{ runner.os }}-mx-${{ hashFiles('**/suite.py') }}
+        restore-keys: ${{ runner.os }}-mx-
+    - name: Get JDK
+      env:
+        JDK: "labsjdk-ce-11"
+      run: |
+        mkdir jdk-dl
+        ${MX_PATH}/mx fetch-jdk --java-distribution ${JDK} --to jdk-dl --alias ${JAVA_HOME}
+    - name: Build GraalVM
+      env:
+        DISABLE_LIBPOLYGLOT: true
+        DISABLE_POLYGLOT: true
+        FORCE_BASH_LAUNCHERS: false
+        LINKY_LAYOUT: *.jar
+      run: |
+        echo ${JAVA_HOME}
+        ${JAVA_HOME}/bin/java -version
+        ${MX_PATH}/mx --primary-suite-path vm --dy /substratevm build
+    - name: Create distribution
+      run: |
+        mv vm/latest_graalvm_home graalvm-svm-darwin-gluon-${RELEASE_VERSION}
+        cd vm && zip -r ../graalvm-svm-darwin-gluon-${RELEASE_VERSION}.zip graalvm-svm-darwin-gluon-${RELEASE_VERSION}
+    - name: Archive distribution
+        uses: actions/upload-artifact@v2
+        with:
+          name: graalvm-zip-darwin
+          path: |
+            graalvm-svm-darwin-gluon-${RELEASE_VERSION}.zip
+
+
+jobs:
+  build-graalvm-windows:
+    runs-on: windows-2019
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+    - uses: actions/checkout@v2
+      with:
+        repository: graalvm/mx.git
+        fetch-depth: 1
+        ref: master
+        path: ${{ env.MX_PATH }}
+    - uses: actions/cache@v1
+      with:
+        path: ~/.mx
+        key: ${{ runner.os }}-mx-${{ hashFiles('**/suite.py') }}
+        restore-keys: ${{ runner.os }}-mx-
+    - name: Get JDK
+      env:
+        JDK: "labsjdk-ce-11"
+      run: |
+        mkdir jdk-dl
+        ${MX_PATH}/mx fetch-jdk --java-distribution ${JDK} --to jdk-dl --alias ${JAVA_HOME}
+    - name: Build GraalVM
+      env:
+        DEFAULT_DYNAMIC_IMPORTS=/substratevm,/tools
+        EXCLUDE_COMPONENTS=nju,llp,dis,pbm,llmulrl
+        FORCE_BASH_LAUNCHERS=polyglot
+        SKIP_LIBRARIES=polyglot
+      run: |
+        echo ${JAVA_HOME}
+        ${JAVA_HOME}/bin/java -version
+        ${MX_PATH}/mx --primary-suite-path vm build
+    - name: Create distribution
+      env:
+        DEFAULT_DYNAMIC_IMPORTS=/substratevm,/tools
+        EXCLUDE_COMPONENTS=nju,llp,dis,pbm,llmulrl
+        FORCE_BASH_LAUNCHERS=polyglot
+        SKIP_LIBRARIES=polyglot
+      run: |
+        mv vm/latest_graalvm_home graalvm-svm-windows-gluon-${RELEASE_VERSION}
+        cd vm && zip -r ../graalvm-svm-windows-gluon-${RELEASE_VERSION}.zip graalvm-svm-windows-gluon-${RELEASE_VERSION}
+    - name: Archive distribution
+        uses: actions/upload-artifact@v2
+        with:
+          name: graalvm-zip-windows
+          path: |
+            graalvm-svm-windows-gluon-${RELEASE_VERSION}.zip
+
+jobs:
+  create-release:
+    runs-on: ubuntu-20.04
+    needs:
+      - build-graalvm-linux
+      - build-graalvm-darwin
+      - build-graalvm-windows
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+    - uses: actions/download-artifact@v2
+      with:
+        path: artifacts
+    - name: Create release
+      uses: ncipollo/release-action@v1
+      with:
+        name: GraalVM CE Gluon ${{ github.ref }}
+        body: |
+          This is a Gluon build of GraalVM.
+          Based on Gluon Graal commit: ${{ github.sha }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+        artifacts: artifacts/*.zip


### PR DESCRIPTION
Add a new GitHub Action workflow to release Gluon builds whenever a tag is being pushed. The generated GraalVM artifacts are attached as assets to a GitHub release in this repository.