### PR TITLE
Replace stat64 symbols with stat symbols on Darwin

### DIFF
--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/PosixStat.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/PosixStat.java
@@ -44,8 +44,8 @@ public final class PosixStat {
             LinuxStat.stat64 stat = StackValue.get(LinuxStat.stat64.class);
             result = LinuxStat.fstat64(fd, stat);
         } else if (Platform.includedIn(Platform.DARWIN.class)) {
-            DarwinStat.stat64 stat = StackValue.get(DarwinStat.stat64.class);
-            result = DarwinStat.fstat64(fd, stat);
+            DarwinStat.stat stat = StackValue.get(DarwinStat.stat.class);
+            result = DarwinStat.fstat(fd, stat);
         } else {
             throw VMError.shouldNotReachHere("Unsupported platform");
         }
@@ -62,8 +62,8 @@ public final class PosixStat {
                 size = stat.st_size();
             }
         } else if (Platform.includedIn(Platform.DARWIN.class)) {
-            DarwinStat.stat64 stat = StackValue.get(DarwinStat.stat64.class);
-            if (DarwinStat.NoTransitions.fstat64(fd, stat) == 0) {
+            DarwinStat.stat stat = StackValue.get(DarwinStat.stat.class);
+            if (DarwinStat.NoTransitions.fstat(fd, stat) == 0) {
                 size = stat.st_size();
             }
         }

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/PosixDirectives.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/PosixDirectives.java
@@ -95,6 +95,6 @@ public class PosixDirectives implements CContext.Directives {
 
     @Override
     public List<String> getMacroDefinitions() {
-        return Arrays.asList("_GNU_SOURCE", "_LARGEFILE64_SOURCE");
+        return Arrays.asList("_GNU_SOURCE", "_LARGEFILE64_SOURCE", "_DARWIN_USE_64_BIT_INODE");
     }
 }

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/darwin/DarwinStat.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/darwin/DarwinStat.java
@@ -40,17 +40,23 @@ import com.oracle.svm.core.posix.headers.PosixDirectives;
 @CContext(PosixDirectives.class)
 public class DarwinStat {
 
+    /*
+     * NOTE that we set _DARWIN_USE_64_BIT_INODE in the C directives to force a layout for struct
+     * stat with a 64-bit st_ino, and we have to call functions with a $INODE64 suffix to match,
+     * such as fstat$INODE64.
+     */
+
     @CStruct(addStructKeyword = true)
-    public interface stat64 extends PointerBase {
+    public interface stat extends PointerBase {
         @CField
         long st_size();
     }
 
-    @CFunction("fstat64")
-    public static native int fstat64(int fd, stat64 buf);
+    @CFunction("fstat$INODE64")
+    public static native int fstat(int fd, stat buf);
 
     public static class NoTransitions {
-        @CFunction(transition = CFunction.Transition.NO_TRANSITION)
-        public static native int fstat64(int fd, stat64 buf);
+        @CFunction(value = "fstat$INODE64", transition = CFunction.Transition.NO_TRANSITION)
+        public static native int fstat(int fd, stat buf);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/oracle/graal/pull/3668 and includes additional [patch](https://github.com/oracle/graal/pull/3668#discussion_r695518073)