### PR TITLE
don't use cpu_set on Android. This is required to make JvmFUncs compi…

### DIFF
--- a/substratevm/src/com.oracle.svm.native.jvm.posix/src/JvmFuncs.c
+++ b/substratevm/src/com.oracle.svm.native.jvm.posix/src/JvmFuncs.c
@@ -79,6 +79,7 @@ JNIEXPORT int JNICALL JVM_GetInterfaceVersion() {
 }
 
 #ifdef __linux__
+#ifndef ANDROID
 /*
   Support for cpusets on Linux (JDK-6515172).
 
@@ -144,10 +145,11 @@ static int linux_active_processor_count() {
   assert(cpu_count > 0 && cpu_count <= configured_cpus, "sanity check");
   return cpu_count;
 }
+#endif /* ANDROID */
 #endif /* __linux__ */
 
 JNIEXPORT int JNICALL JVM_ActiveProcessorCount() {
-#ifdef __linux__
+#if defined  __linux__ && !defined ANDROID
     return linux_active_processor_count();
 #else
     return sysconf(_SC_NPROCESSORS_ONLN);


### PR DESCRIPTION
This is required to make JvmFUncs compile on Android, which is needed for a new libc build related to Substrate issue #1002