### PR TITLE
Patch java.io.tmpdir

### DIFF
--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/linux/LinuxSystemPropertiesSupport.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/linux/LinuxSystemPropertiesSupport.java
@@ -46,7 +46,9 @@ public class LinuxSystemPropertiesSupport extends PosixSystemPropertiesSupport {
          * to be completely correct, we would have to use the value from libjava, but since it is
          * normally initialized to `/tmp` via `P_tmpdir`, this should be fine for now.
          */
-        return "/tmp";
+        // On Android, this property should be set before GraalVM is launched, with the 
+        // path of the application's sandbox as tmp dir:
+        return System.getProperty("android.tmpdir", "/tmp");
     }
 
     private static final String DEFAULT_LIBPATH = "/usr/lib64:/lib64:/lib:/usr/lib";


### PR DESCRIPTION
Patch `java.io.tmpdir` system property, as `/tmp` doesn't exist on Android, and the path of the application should be used instead.